### PR TITLE
Correct translation and scale for overall Tabula baked model. Similar…

### DIFF
--- a/src/main/java/net/ilexiconn/llibrary/client/model/tabula/baked/VanillaTabulaModel.java
+++ b/src/main/java/net/ilexiconn/llibrary/client/model/tabula/baked/VanillaTabulaModel.java
@@ -58,7 +58,8 @@ public class VanillaTabulaModel implements IModel {
         TextureAtlasSprite sprite = bakedTextureGetter.apply(this.textures.isEmpty() ? new ResourceLocation("missingno") : this.textures.get(0));
         ImmutableList.Builder<BakedQuad> builder = ImmutableList.builder();
         Matrix matrix = new Matrix();
-        matrix.scale(0.0625F, 0.0625F, 0.0625F);
+        matrix.translate(0.5F ,1.5F, 0.5F);
+        matrix.scale(-0.0625F, -0.0625F, 0.0625F);
         this.build(matrix, builder, format, this.model.getCubes(), sprite);
         ImmutableList<BakedQuad> leQuads = builder.build();
         return new BakedTabulaModel(leQuads, sprite, this.transforms);
@@ -73,10 +74,10 @@ public class VanillaTabulaModel implements IModel {
             double[] glScale = cube.getScale();
             int[] txOffset = cube.getTextureOffset();
             mat.push();
+            mat.translate(position[0], position[1], position[2]);
             if (glScale[0] != 1 || glScale[1] != 1 || glScale[2] != 1) {
                 mat.scale(glScale[0], glScale[1], glScale[2]);
             }
-            mat.translate(position[0], position[1], position[2]);
             if (rotation[2] != 0) {
                 mat.rotate(rotation[2], 0, 0, 1);
             }


### PR DESCRIPTION
I'll keep these PRs small:
Specifically this PR applies to only the baked Tabula model loader via json files.
1) Correct translation and scale for overall Tabula baked model. Similar to how the they are applied in a TESR. 

2) For each cube within the model, move the translation before the scale is are applied. 

-1- Overall translation and scale before and after
Basic block in Tabula.
![Basic block in Tabula](https://puu.sh/taz92.png)

Basic block and armor stand model in world before this PR.
![Basic block and armor stand model in world before this PR.](https://puu.sh/tazua.png)

Basic block and armor stand after this PR.
![Basic block and armor stand after this PR.](https://puu.sh/tazvf.png)

-2- For each cube within the model, move the translation before the scale is are applied.  before and after PR. In this case a baked Tabula item.

Violin model rendered in Tabula. Note string spacing
![Model rendered in Tabula](https://puu.sh/sWboT.png)

Left: Baked Tabula Item before - strings spacing is incorrect
![Left: Baked Tabula Item before](https://puu.sh/ta4Is.png)

After these changes the strings are rendered correctly.
![After these changes the strings are rendered correctly.](https://puu.sh/ta5E2.png)