### PR TITLE
Restrict usage of the baked tabula model loader to registered mods

### DIFF
--- a/src/main/java/net/ilexiconn/llibrary/client/ClientProxy.java
+++ b/src/main/java/net/ilexiconn/llibrary/client/ClientProxy.java
@@ -51,6 +51,7 @@ public class ClientProxy extends ServerProxy {
 
         MinecraftForge.EVENT_BUS.register(ClientEventHandler.INSTANCE);
         ModelLoaderRegistry.registerLoader(TabulaModelHandler.INSTANCE);
+        TabulaModelHandler.INSTANCE.addDomain("llibrary");
         RenderingRegistry.registerEntityRenderingHandler(PartEntity.class, new PartRenderer.Factory());
 
         Thread thread = new Thread(LanguageHandler.INSTANCE::load);

--- a/src/main/java/net/ilexiconn/llibrary/client/model/tabula/TabulaModelHandler.java
+++ b/src/main/java/net/ilexiconn/llibrary/client/model/tabula/TabulaModelHandler.java
@@ -7,6 +7,7 @@ import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
+import net.ilexiconn.llibrary.LLibrary;
 import net.ilexiconn.llibrary.client.model.tabula.baked.VanillaTabulaModel;
 import net.ilexiconn.llibrary.client.model.tabula.baked.deserializer.ItemCameraTransformsDeserializer;
 import net.ilexiconn.llibrary.client.model.tabula.baked.deserializer.ItemTransformVec3fDeserializer;
@@ -30,7 +31,9 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -46,7 +49,13 @@ public enum TabulaModelHandler implements ICustomModelLoader, JsonDeserializatio
     private JsonParser parser = new JsonParser();
     private ModelBlock.Deserializer modelBlockDeserializer = new ModelBlock.Deserializer();
     private IResourceManager manager;
-
+    private final Set<String> enabledDomains = new HashSet<String>();
+    
+    public void addDomain(String domain) {
+        enabledDomains.add(domain.toLowerCase());
+        LLibrary.LOGGER.info("TabulaModelHandler: Domain %s has been added.", domain.toLowerCase());
+    }
+    
     /**
      * Load a {@link TabulaModelContainer} from the path. A slash will be added if it isn't in the path already.
      *
@@ -160,7 +169,7 @@ public enum TabulaModelHandler implements ICustomModelLoader, JsonDeserializatio
 
     @Override
     public boolean accepts(ResourceLocation modelLocation) {
-        return modelLocation.getResourcePath().endsWith(".tbl");
+        return enabledDomains.contains(modelLocation.getResourceDomain()) && modelLocation.getResourcePath().endsWith(".tbl");
     }
 
     @Override


### PR DESCRIPTION
The purpose of this PR to prevent multi-loader contention with LLibrary's baked Tabula ICustomModelLoader.
That is files with the .tbl extension when used with the baked Tabula custom model loader (TabulaModelHandler).

Forge will not choose one over the other, it will simply spew errors and use the missing model instead. Obviously this is not a nice thing.

This will not affect loading tabula files directly. e.g. like how JurassiCraft2 handles Renderers for entities and tile entities.
e.g.
```java
this.model = new ResetControlTabulaModel(TabulaModelHelper.loadTabulaModel("/assets/jurassicraft/models/block/feeder.tbl"));
```

This PR will allow the mod author to choose if they want to use LLibrary's custom model loader or not.
They will have to register thier modid with the loader to use it with their mod. Just like they would to use the .OBJ and .B3D loaders in Forge.
e.g.
```java
// Forge already requires registering the mods modid/domain to use these
OBJLoader.INSTANCE.addDomain("somemod");
B3DLoader.INSTANCE.addDomain("somemod");
// Mod authors will need to add the mods modid to use LLibrary's ICustomModelLoader for Tabula files
TabulaModelHandler.INSTANCE.addDomain("somemod"); 
```

Example of two mods, one using LLibrary's baked Tabula custom model loader and the other using it's own loader.
The OWN loader mod is already domain aware.

Before PR:
"2 loaders ... want to load the same model ..."
OMG!  (╯°□°）╯︵ ┻━┻
![2 loaders ... want to load the same model ...](https://puu.sh/tcJLQ.png)

Mod using LLibrary displays it's models just fine.
Mod using OWN loader has missing models.
TESR models are not affected.
![](https://media.giphy.com/media/11ktD16Kqv6K5i/giphy.gif)

After PR, but before mod using LLibrary adds its domain to the loader:
Mod using LLibrary displays now has the missing models.
Mod using OWN loader now displays models as expected.
TESR models are not affected.
![](https://media.giphy.com/media/LL8iIhbWm8Qta/giphy.gif)

After PR and after mod using LLibrary adds its domain to the loader:
Both mods now display models correctly, each using their specified loaders.
![](https://media.giphy.com/media/a7i8fWpjkEdJ6/giphy.gif)

Joy!
 \(◦'⌣'◦)/