### PR TITLE
Change the LOGGER to use a string formatter.

### DIFF
--- a/src/main/java/net/ilexiconn/llibrary/LLibrary.java
+++ b/src/main/java/net/ilexiconn/llibrary/LLibrary.java
@@ -27,7 +27,7 @@ import org.apache.logging.log4j.Logger;
 @Mod(modid = "llibrary", name = "LLibrary", version = LLibrary.VERSION, guiFactory = "net.ilexiconn.llibrary.client.gui.LLibraryGUIFactory")
 public class LLibrary {
     public static final String VERSION = "1.7.4";
-    public static final Logger LOGGER = LogManager.getLogger("LLibrary");
+    public static final Logger LOGGER = LogManager.getFormatterLogger("LLibrary");
     @SidedProxy(serverSide = "net.ilexiconn.llibrary.server.ServerProxy", clientSide = "net.ilexiconn.llibrary.client.ClientProxy")
     public static ServerProxy PROXY;
     @Mod.Instance("llibrary")


### PR DESCRIPTION
Easy change to enable the string formatter for logging. See ModLogger.getFormatterLogger(final String name) for details.

Issue:
After the addDomain method was added to the TabulaModelHandler class I noticed that LLibrary.LOGGER did not handle formated messages. It just prints the message and does not sub in the arguments
e.g.
```java
LLibrary.LOGGER.info("TabulaModelHandler: Domain %s has been added.", domain.toLowerCase());
```
This prints in the log file as:  [LLibrary] TabulaModelHandler: Domain %s has been added.