### PR TITLE
ASM improvements

### DIFF
--- a/src/main/java/net/ilexiconn/llibrary/server/asm/ClassPatcher.java
+++ b/src/main/java/net/ilexiconn/llibrary/server/asm/ClassPatcher.java
@@ -9,19 +9,6 @@ import java.util.*;
 import java.util.function.Consumer;
 
 public class ClassPatcher {
-    private static final Map<String, String> PRIMITIVE_NAMES = new HashMap<>();
-
-    static {
-        PRIMITIVE_NAMES.put("void", "V");
-        PRIMITIVE_NAMES.put("boolean", "Z");
-        PRIMITIVE_NAMES.put("char", "C");
-        PRIMITIVE_NAMES.put("byte", "B");
-        PRIMITIVE_NAMES.put("short", "S");
-        PRIMITIVE_NAMES.put("int", "I");
-        PRIMITIVE_NAMES.put("float", "F");
-        PRIMITIVE_NAMES.put("long", "J");
-        PRIMITIVE_NAMES.put("double", "D");
-    }
 
     private String cls;
     private Map<String, MethodPatcher> patcherMap = new HashMap<>();
@@ -59,7 +46,7 @@ public class ClassPatcher {
     }
 
     public MethodPatcher patchMethod(String method, Object... params) {
-        String desc = MappingHandler.INSTANCE.getClassMapping(this.methodDesc(params));
+        String desc = MappingHandler.INSTANCE.getClassMapping(Descriptors.method(params));
         method = MappingHandler.INSTANCE.getMethodMapping(this.cls, method, desc) + desc;
         MethodPatcher patcher = new MethodPatcher(this, this.cls, method);
         this.patcherMap.put(method, patcher);
@@ -67,64 +54,17 @@ public class ClassPatcher {
     }
 
     public ClassPatcher createMethod(String method, Object[] params, Consumer<Method> consumer) {
-        String desc = MappingHandler.INSTANCE.getClassMapping(this.methodDesc(params));
+        String desc = MappingHandler.INSTANCE.getClassMapping(Descriptors.method(params));
         method = MappingHandler.INSTANCE.getMethodMapping(this.cls, method, desc) + desc;
         this.creationMap.put(method, consumer);
         return this;
     }
 
     public ClassPatcher removeMethod(String method, Object... params) {
-        String desc = MappingHandler.INSTANCE.getClassMapping(this.methodDesc(params));
+        String desc = MappingHandler.INSTANCE.getClassMapping(Descriptors.method(params));
         method = MappingHandler.INSTANCE.getMethodMapping(this.cls, method, desc) + desc;
         this.removeList.add(method);
         return this;
-    }
-
-    String methodDesc(Object... params) {
-        if (params.length == 0) {
-            return "";
-        }
-        StringBuilder builder = new StringBuilder("(");
-        for (int i = 0; i < params.length - 1; i++) {
-            Object obj = params[i];
-            if (obj instanceof Integer) {
-                String desc = this.fieldDesc(params[++i]);
-                for (int j = 0, k = (int) obj; j < k; j++) {
-                    builder.append(desc);
-                }
-            } else {
-                builder.append(this.fieldDesc(obj));
-            }
-        }
-        builder.append(")").append(this.fieldDesc(params[params.length - 1]));
-        return builder.toString();
-    }
-
-    String fieldDesc(Object obj) {
-        String result = "";
-        String suffix = "";
-        if (obj instanceof String) {
-            String cls = MappingHandler.INSTANCE.getClassMapping((String) obj);
-            result = PRIMITIVE_NAMES.get(cls);
-            if (result == null) {
-                result = "L" + cls;
-                suffix = ";";
-            }
-        } else if (obj instanceof Class) {
-            Class cls = (Class) obj;
-            result = PRIMITIVE_NAMES.get(cls.getName());
-            if (result == null) {
-                if (!cls.isArray()) {
-                    return "L" + cls.getName() + ";";
-                } else {
-                    return cls.getName();
-                }
-            }
-        }
-        while (result.endsWith("[]")) {
-            result = "[" + result.substring(0, result.length() - 2);
-        }
-        return result + suffix;
     }
 
     @Override

--- a/src/main/java/net/ilexiconn/llibrary/server/asm/Descriptors.java
+++ b/src/main/java/net/ilexiconn/llibrary/server/asm/Descriptors.java
@@ -1,0 +1,67 @@
+package net.ilexiconn.llibrary.server.asm;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Descriptors {
+    private static final Map<String, String> PRIMITIVE_NAMES = new HashMap<>();
+
+    static {
+        PRIMITIVE_NAMES.put("void", "V");
+        PRIMITIVE_NAMES.put("boolean", "Z");
+        PRIMITIVE_NAMES.put("char", "C");
+        PRIMITIVE_NAMES.put("byte", "B");
+        PRIMITIVE_NAMES.put("short", "S");
+        PRIMITIVE_NAMES.put("int", "I");
+        PRIMITIVE_NAMES.put("float", "F");
+        PRIMITIVE_NAMES.put("long", "J");
+        PRIMITIVE_NAMES.put("double", "D");
+    }
+
+    public static String method(Object... params) {
+        if (params.length == 0) {
+            return "";
+        }
+        StringBuilder builder = new StringBuilder("(");
+        for (int i = 0; i < params.length - 1; i++) {
+            Object obj = params[i];
+            if (obj instanceof Integer) {
+                String desc = field(params[++i]);
+                for (int j = 0, k = (int) obj; j < k; j++) {
+                    builder.append(desc);
+                }
+            } else {
+                builder.append(field(obj));
+            }
+        }
+        builder.append(")").append(field(params[params.length - 1]));
+        return builder.toString();
+    }
+
+    public static String field(Object obj) {
+        String result = "";
+        String suffix = "";
+        if (obj instanceof String) {
+            String cls = MappingHandler.INSTANCE.getClassMapping((String) obj);
+            result = PRIMITIVE_NAMES.get(cls);
+            if (result == null) {
+                result = "L" + cls;
+                suffix = ";";
+            }
+        } else if (obj instanceof Class) {
+            Class cls = (Class) obj;
+            result = PRIMITIVE_NAMES.get(cls.getName());
+            if (result == null) {
+                if (!cls.isArray()) {
+                    return "L" + cls.getName() + ";";
+                } else {
+                    return cls.getName();
+                }
+            }
+        }
+        while (result.endsWith("[]")) {
+            result = "[" + result.substring(0, result.length() - 2);
+        }
+        return result + suffix;
+    }
+}

--- a/src/main/java/net/ilexiconn/llibrary/server/asm/InsnPredicate.java
+++ b/src/main/java/net/ilexiconn/llibrary/server/asm/InsnPredicate.java
@@ -1,0 +1,127 @@
+package net.ilexiconn.llibrary.server.asm;
+
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.*;
+
+import java.util.function.Predicate;
+
+public abstract class InsnPredicate implements Predicate<MethodPatcher.PredicateData> {
+    public static final Predicate<Integer> RETURNING = opcode -> opcode == Opcodes.RETURN || opcode == Opcodes.IRETURN || opcode == Opcodes.LRETURN || opcode == Opcodes.FRETURN || opcode == Opcodes.DRETURN || opcode == Opcodes.ARETURN;
+
+    protected Predicate<Integer> opcodePredicate = opcode -> true;
+
+    public InsnPredicate opcode(Predicate<Integer> opcodePredicate) {
+        this.opcodePredicate = opcodePredicate;
+        return this;
+    }
+
+    public InsnPredicate opcode(int _opcode) {
+        return this.opcode(opcode -> opcode == _opcode);
+    }
+
+    @Override
+    public boolean test(MethodPatcher.PredicateData predicateData) {
+        return opcodePredicate.test(predicateData.node.getOpcode());
+    }
+
+    public static class Op extends InsnPredicate {
+        @Override
+        public boolean test(MethodPatcher.PredicateData predicateData) {
+            if (predicateData.node instanceof InsnNode) {
+                return super.test(predicateData);
+            } else {
+                return false;
+            }
+        }
+    }
+
+    public static class Ldc extends InsnPredicate {
+        protected Predicate<Object> cstPredicate = cst -> true;
+
+        public Ldc cst(Predicate<Object> cstPredicate) {
+            this.cstPredicate = cstPredicate;
+            return this;
+        }
+
+        public Ldc cst(Object _cst) {
+            return this.cst(cst -> cst.equals(_cst));
+        }
+
+        @Override
+        public boolean test(MethodPatcher.PredicateData predicateData) {
+            if (predicateData.node instanceof LdcInsnNode) {
+                LdcInsnNode node = (LdcInsnNode) predicateData.node;
+                return super.test(predicateData) && this.cstPredicate.test(node.cst);
+            } else {
+                return false;
+            }
+        }
+    }
+
+    public static class Method extends InsnPredicate {
+        protected final String owner;
+        protected final String desc;
+        protected final String name;
+
+        public Method(Object owner, String name, Object... desc) {
+            this.owner = MappingHandler.INSTANCE.getClassMapping(owner);
+            this.desc = MappingHandler.INSTANCE.getClassMapping(Descriptors.method(desc));
+            this.name = MappingHandler.INSTANCE.getMethodMapping(owner, name, this.desc);
+        }
+
+        @Override
+        public boolean test(MethodPatcher.PredicateData predicateData) {
+            if (predicateData.node instanceof MethodInsnNode) {
+                MethodInsnNode node = (MethodInsnNode) predicateData.node;
+                return super.test(predicateData) && this.owner.equals(node.owner) && this.desc.equals(node.desc) && this.name.equals(node.name);
+            } else {
+                return false;
+            }
+        }
+    }
+
+    public static class Field extends InsnPredicate {
+        protected final String owner;
+        protected final String desc;
+        protected final String name;
+
+        public Field(Object owner, String name, Object desc) {
+            this.owner = MappingHandler.INSTANCE.getClassMapping(owner);
+            this.desc = MappingHandler.INSTANCE.getClassMapping(Descriptors.field(desc));
+            this.name = MappingHandler.INSTANCE.getFieldMapping(owner, name);
+        }
+
+        @Override
+        public boolean test(MethodPatcher.PredicateData predicateData) {
+            if (predicateData.node instanceof FieldInsnNode) {
+                FieldInsnNode node = (FieldInsnNode) predicateData.node;
+                return super.test(predicateData) && this.owner.equals(node.owner) && this.desc.equals(node.desc) && this.name.equals(node.name);
+            } else {
+                return false;
+            }
+        }
+    }
+
+    public static class Var extends InsnPredicate {
+        protected Predicate<Integer> varPredicate = index -> true;
+
+        public Var var(Predicate<Integer> varPredicate) {
+            this.varPredicate = varPredicate;
+            return this;
+        }
+
+        public Var var(int _var) {
+            return this.var(var -> var == _var);
+        }
+
+        @Override
+        public boolean test(MethodPatcher.PredicateData predicateData) {
+            if (predicateData.node instanceof VarInsnNode) {
+                VarInsnNode node = (VarInsnNode) predicateData.node;
+                return super.test(predicateData) && this.varPredicate.test(node.var);
+            } else {
+                return false;
+            }
+        }
+    }
+}

--- a/src/main/java/net/ilexiconn/llibrary/server/asm/Method.java
+++ b/src/main/java/net/ilexiconn/llibrary/server/asm/Method.java
@@ -34,7 +34,7 @@ public class Method {
     public Method field(int opcode, Object obj, String name, Object type) {
         if (obj instanceof String) {
             String cls = MappingHandler.INSTANCE.getClassMapping((String) obj);
-            String desc = MappingHandler.INSTANCE.getClassMapping(this.patcher.fieldDesc(type));
+            String desc = MappingHandler.INSTANCE.getClassMapping(Descriptors.field(type));
             this.insnList.add(new FieldInsnNode(opcode, cls, MappingHandler.INSTANCE.getFieldMapping(cls, name), desc));
         }
         return this;
@@ -86,7 +86,7 @@ public class Method {
     public Method method(int opcode, Object obj, String name, Object... params) {
         if (obj instanceof String) {
             String cls = MappingHandler.INSTANCE.getClassMapping((String) obj);
-            String desc = MappingHandler.INSTANCE.getClassMapping(this.patcher.methodDesc(params));
+            String desc = MappingHandler.INSTANCE.getClassMapping(Descriptors.method(params));
             this.insnList.add(new MethodInsnNode(opcode, cls, MappingHandler.INSTANCE.getMethodMapping(cls, name, desc), desc, opcode == Opcodes.INVOKEINTERFACE));
         }
         return this;

--- a/src/main/java/net/ilexiconn/llibrary/server/asm/RuntimePatcher.java
+++ b/src/main/java/net/ilexiconn/llibrary/server/asm/RuntimePatcher.java
@@ -128,7 +128,7 @@ public abstract class RuntimePatcher implements IClassTransformer, Opcodes {
                         if (predicateData.node instanceof MethodInsnNode) {
                             MethodInsnNode methodNode = (MethodInsnNode) predicateData.node;
                             if (this.mappedDesc == null) {
-                                this.mappedDesc = MappingHandler.INSTANCE.getClassMapping(predicateData.patcher.methodDesc(Arrays.copyOfRange(args, 1, args.length)));
+                                this.mappedDesc = MappingHandler.INSTANCE.getClassMapping(Descriptors.method(Arrays.copyOfRange(args, 1, args.length)));
                             }
                             if (this.mappedName == null) {
                                 this.mappedName = MappingHandler.INSTANCE.getMethodMapping(predicateData.cls, (String) args[0], this.mappedDesc);

--- a/src/main/java/net/ilexiconn/llibrary/server/core/patcher/LLibraryRuntimePatcher.java
+++ b/src/main/java/net/ilexiconn/llibrary/server/core/patcher/LLibraryRuntimePatcher.java
@@ -1,6 +1,7 @@
 package net.ilexiconn.llibrary.server.core.patcher;
 
 import net.ilexiconn.llibrary.client.lang.LanguageHandler;
+import net.ilexiconn.llibrary.server.asm.InsnPredicate;
 import net.ilexiconn.llibrary.server.asm.RuntimePatcher;
 import net.ilexiconn.llibrary.server.world.TickRateHandler;
 import net.minecraft.client.entity.AbstractClientPlayer;
@@ -23,7 +24,7 @@ public class LLibraryRuntimePatcher extends RuntimePatcher {
     public void onInit() {
         this.patchClass(Locale.class)
             .patchMethod("loadLocaleDataFiles", IResourceManager.class, List.class, void.class)
-                .apply(Patch.BEFORE, this.at(At.METHOD, "format", String.class, Object[].class, String.class), method -> {
+                .apply(Patch.BEFORE, new InsnPredicate.Method(String.class, "format", String.class, Object[].class, String.class), method -> {
                     method.field(GETSTATIC, LanguageHandler.class, "INSTANCE", LanguageHandler.class);
                     method.var(ALOAD, 4).var(ALOAD, 0);
                     method.field(GETFIELD, Locale.class, "properties", Map.class);
@@ -32,17 +33,17 @@ public class LLibraryRuntimePatcher extends RuntimePatcher {
 
         this.patchClass(ModelPlayer.class)
             .patchMethod("setRotationAngles", 6, float.class, Entity.class, void.class)
-                .apply(Patch.BEFORE, this.at(At.RETURN), method -> {
+                .apply(Patch.BEFORE, new InsnPredicate.Op().opcode(InsnPredicate.RETURNING), method -> {
                     method.var(ALOAD, 0).var(ALOAD, 7).var(FLOAD, 1, 6);
                     method.method(INVOKESTATIC, LLibraryHooks.class, "setRotationAngles", ModelPlayer.class, Entity.class, 6, float.class, void.class);
                 }).pop()
             .patchMethod("render", Entity.class, 6, float.class, void.class)
-                .apply(Patch.BEFORE, this.at(At.RETURN), method -> {
+                .apply(Patch.BEFORE, new InsnPredicate.Op().opcode(InsnPredicate.RETURNING), method -> {
                     method.var(ALOAD, 0, 1).var(FLOAD, 2, 7);
                     method.method(INVOKESTATIC, LLibraryHooks.class, "renderModel", ModelPlayer.class, Entity.class, 6, float.class, void.class);
                 }).pop()
             .patchMethod("<init>", float.class, boolean.class, void.class)
-                .apply(Patch.BEFORE, this.at(At.RETURN), method -> {
+                .apply(Patch.BEFORE, new InsnPredicate.Op().opcode(InsnPredicate.RETURNING), method -> {
                     method.var(ALOAD, 0);
                     method.method(INVOKESTATIC, LLibraryHooks.class, "constructModel", ModelPlayer.class, void.class);
                 }).pop();
@@ -63,7 +64,7 @@ public class LLibraryRuntimePatcher extends RuntimePatcher {
                     method.node(RETURN);
                 }).pop()
             .patchMethod("<init>", RenderManager.class, boolean.class, void.class)
-                .apply(Patch.BEFORE, this.at(At.RETURN), method -> {
+                .apply(Patch.BEFORE, new InsnPredicate.Op().opcode(InsnPredicate.RETURNING), method -> {
                     method.var(ALOAD, 0).var(ALOAD, 0).var(ALOAD, 0);
                     method.method(INVOKEVIRTUAL, RenderPlayer.class, "getMainModel", ModelPlayer.class);
                     method.var(ALOAD, 0);
@@ -74,7 +75,7 @@ public class LLibraryRuntimePatcher extends RuntimePatcher {
 
         this.patchClass(MinecraftServer.class)
             .patchMethod("run", void.class)
-                .apply(Patch.REPLACE_NODE, this.at(At.LDC, 50L), method -> {
+                .apply(Patch.REPLACE_NODE, new InsnPredicate.Ldc().cst(50L), method -> {
                     method.field(GETSTATIC, TickRateHandler.class, "INSTANCE", TickRateHandler.class);
                     method.method(INVOKEVIRTUAL, TickRateHandler.class, "getTickRate", long.class);
                 }).pop();


### PR DESCRIPTION
There are a few things done here.

1. It moves methodDesc and fieldDesc out of ClassPatcher and into Descriptors as static methods. This makes more sense as methodDesc and fieldDesc are stateless general purpose functions that have no need to be package-private.
2. It improves MappingHandler performance. Previously it would iterate through the map instead of using the quick lookup of the underlying HashMap. In addition, it splits the map into fields and methods.
3. It implements an alternative way to create RuntimePatcher predicates. The previous implementation has a serious design flaw where all METHOD predicates are expected to belong to the class being patched. The set of available predicates is also arguably small, so a few more predicates have been added.