### PR TITLE
Implement a fast and descriptive fail when RuntimePatcher has not been transformed

### DIFF
--- a/src/main/java/net/ilexiconn/llibrary/server/asm/RuntimePatcher.java
+++ b/src/main/java/net/ilexiconn/llibrary/server/asm/RuntimePatcher.java
@@ -31,6 +31,13 @@ import java.util.function.Predicate;
 public abstract class RuntimePatcher implements IClassTransformer, Opcodes {
     private Map<String, ClassPatcher> patcherMap = new HashMap<>();
 
+    public RuntimePatcher() {
+        // Do not implement the annotation manually. It will be injected by LLibraryTransformer
+        if (this.getClass().getAnnotation(Transformed.class) == null) {
+            throw new RuntimeException("RuntimePatcher has not been transformed and cannot be loaded.");
+        }
+    }
+
     public abstract void onInit();
 
     @Override

--- a/src/main/java/net/ilexiconn/llibrary/server/asm/Transformed.java
+++ b/src/main/java/net/ilexiconn/llibrary/server/asm/Transformed.java
@@ -1,0 +1,11 @@
+package net.ilexiconn.llibrary.server.asm;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Annotation injected into RuntimePatchers by LLibraryTransformer to indicate that the class has been transformed.
+ * This annotation is not to be implemented manually.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Transformed {}

--- a/src/main/java/net/ilexiconn/llibrary/server/core/plugin/LLibraryTransformer.java
+++ b/src/main/java/net/ilexiconn/llibrary/server/core/plugin/LLibraryTransformer.java
@@ -1,5 +1,7 @@
 package net.ilexiconn.llibrary.server.core.plugin;
 
+import net.ilexiconn.llibrary.server.asm.Descriptors;
+import net.ilexiconn.llibrary.server.asm.MappingHandler;
 import net.minecraft.launchwrapper.IClassTransformer;
 import net.minecraftforge.fml.relauncher.FMLRelaunchLog;
 import org.objectweb.asm.ClassReader;
@@ -7,6 +9,8 @@ import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.*;
+
+import java.util.ArrayList;
 
 public class LLibraryTransformer implements IClassTransformer {
     private static final String RUNTIME_PATCHER = "RuntimePatcher";
@@ -33,6 +37,8 @@ public class LLibraryTransformer implements IClassTransformer {
                     }
                 }
             }
+
+            classNode.visitAnnotation("Lnet/ilexiconn/llibrary/server/asm/Transformed;", true);
 
             ClassWriter classWriter = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
             classNode.accept(classWriter);

--- a/src/main/java/net/ilexiconn/llibrary/server/core/plugin/LLibraryTransformer.java
+++ b/src/main/java/net/ilexiconn/llibrary/server/core/plugin/LLibraryTransformer.java
@@ -1,7 +1,5 @@
 package net.ilexiconn.llibrary.server.core.plugin;
 
-import net.ilexiconn.llibrary.server.asm.Descriptors;
-import net.ilexiconn.llibrary.server.asm.MappingHandler;
 import net.minecraft.launchwrapper.IClassTransformer;
 import net.minecraftforge.fml.relauncher.FMLRelaunchLog;
 import org.objectweb.asm.ClassReader;
@@ -9,8 +7,6 @@ import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.*;
-
-import java.util.ArrayList;
 
 public class LLibraryTransformer implements IClassTransformer {
     private static final String RUNTIME_PATCHER = "RuntimePatcher";


### PR DESCRIPTION
This makes LLibraryTransformer inject an annotation in the classes it transforms. The RuntimePatcher constructor verifies that this annotation is present.

In the event that a RuntimePatcher is not transformed, constructing the RuntimePatcher will result in a RuntimeException. This prevents classes from any leaked Class references from being loaded causing ClassCircularityErrors. The RuntimeException is caught by FML which logs the exception and continues loading the game.

There is one exception to the fast fail which is Class references in the static initializer. I don't see any need to use the static initializer in the first place, though.