### PR TITLE
Added support for layered textures and tinting with taubla models

### DIFF
--- a/src/main/java/net/ilexiconn/llibrary/client/model/tabula/baked/VanillaTabulaModel.java
+++ b/src/main/java/net/ilexiconn/llibrary/client/model/tabula/baked/VanillaTabulaModel.java
@@ -64,7 +64,7 @@ public class VanillaTabulaModel implements IModel {
             locations.add(new ResourceLocation("missingno"));
         }
         ImmutableList.Builder<BakedQuad> builder = ImmutableList.builder();
-        TextureAtlasSprite particleSprite = this.particle == null ? bakedTextureGetter.apply(locations.get(0)) : bakedTextureGetter.apply(this.particle);
+        TextureAtlasSprite particleSprite = bakedTextureGetter.apply(this.particle == null ? locations.get(0) : this.particle);
         int layer = 0;
         for(ResourceLocation resourceLocation : locations) {
             Matrix matrix = new Matrix();

--- a/src/main/java/net/ilexiconn/llibrary/client/model/tabula/baked/VanillaTabulaModel.java
+++ b/src/main/java/net/ilexiconn/llibrary/client/model/tabula/baked/VanillaTabulaModel.java
@@ -2,6 +2,7 @@ package net.ilexiconn.llibrary.client.model.tabula.baked;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import net.ilexiconn.llibrary.client.model.tabula.container.TabulaCubeContainer;
 import net.ilexiconn.llibrary.client.model.tabula.container.TabulaModelContainer;
 import net.ilexiconn.llibrary.client.util.Matrix;
@@ -58,15 +59,21 @@ public class VanillaTabulaModel implements IModel {
 
     @Override
     public IBakedModel bake(IModelState state, VertexFormat format, Function<ResourceLocation, TextureAtlasSprite> bakedTextureGetter) {
-        TextureAtlasSprite sprite = bakedTextureGetter.apply(this.textures.isEmpty() ? new ResourceLocation("missingno") : this.textures.get(0));
-        TextureAtlasSprite particleSprite = this.particle == null ? sprite : bakedTextureGetter.apply(this.particle);
+        List<ResourceLocation> locations = Lists.newArrayList(this.textures);
+        if(locations.isEmpty()) {
+            locations.add(new ResourceLocation("missingno"));
+        }
         ImmutableList.Builder<BakedQuad> builder = ImmutableList.builder();
-        Matrix matrix = new Matrix();
-        TRSRTransformation transformation = state.apply(Optional.empty()).orElse(TRSRTransformation.identity());
-        matrix.multiply(transformation.getMatrix());
-        matrix.translate(0.5F, 1.5F, 0.5F);
-        matrix.scale(-0.0625F, -0.0625F, 0.0625F);
-        this.build(matrix, builder, format, this.model.getCubes(), sprite);
+        TextureAtlasSprite particleSprite = this.particle == null ? bakedTextureGetter.apply(locations.get(0)) : bakedTextureGetter.apply(this.particle);
+        for(ResourceLocation resourceLocation : locations) {
+            Matrix matrix = new Matrix();
+            TextureAtlasSprite sprite = bakedTextureGetter.apply(resourceLocation);
+            TRSRTransformation transformation = state.apply(Optional.empty()).orElse(TRSRTransformation.identity());
+            matrix.multiply(transformation.getMatrix());
+            matrix.translate(0.5F, 1.5F, 0.5F);
+            matrix.scale(-0.0625F, -0.0625F, 0.0625F);
+            this.build(matrix, builder, format, this.model.getCubes(), sprite);
+        }
         ImmutableList<BakedQuad> leQuads = builder.build();
         return new BakedTabulaModel(leQuads, particleSprite, this.transforms);
     }

--- a/src/main/java/net/ilexiconn/llibrary/client/model/tabula/baked/VanillaTabulaModel.java
+++ b/src/main/java/net/ilexiconn/llibrary/client/model/tabula/baked/VanillaTabulaModel.java
@@ -65,6 +65,7 @@ public class VanillaTabulaModel implements IModel {
         }
         ImmutableList.Builder<BakedQuad> builder = ImmutableList.builder();
         TextureAtlasSprite particleSprite = this.particle == null ? bakedTextureGetter.apply(locations.get(0)) : bakedTextureGetter.apply(this.particle);
+        int layer = 0;
         for(ResourceLocation resourceLocation : locations) {
             Matrix matrix = new Matrix();
             TextureAtlasSprite sprite = bakedTextureGetter.apply(resourceLocation);
@@ -72,13 +73,13 @@ public class VanillaTabulaModel implements IModel {
             matrix.multiply(transformation.getMatrix());
             matrix.translate(0.5F, 1.5F, 0.5F);
             matrix.scale(-0.0625F, -0.0625F, 0.0625F);
-            this.build(matrix, builder, format, this.model.getCubes(), sprite);
+            this.build(matrix, builder, format, this.model.getCubes(), sprite, layer++);
         }
         ImmutableList<BakedQuad> leQuads = builder.build();
         return new BakedTabulaModel(leQuads, particleSprite, this.transforms);
     }
 
-    private void build(Matrix mat, ImmutableList.Builder<BakedQuad> builder, VertexFormat format, List<TabulaCubeContainer> cubeContainerList, TextureAtlasSprite sprite) {
+    private void build(Matrix mat, ImmutableList.Builder<BakedQuad> builder, VertexFormat format, List<TabulaCubeContainer> cubeContainerList, TextureAtlasSprite sprite, int layer) {
         for (TabulaCubeContainer cube : cubeContainerList) {
             int[] dimensions = cube.getDimensions();
             double[] position = cube.getPosition();
@@ -143,13 +144,13 @@ public class VanillaTabulaModel implements IModel {
             Point2i frontMaxUV = new Point2i(u + d + w, v + d + h);
             Point2i backMinUV = new Point2i(u + d + w + d, v + d);
             Point2i backMaxUV = new Point2i(u + d + w + d + w, v + d + h);
-            this.buildQuad(builder, format, isTxMirror, vertex101, vertex100, vertex110, vertex111, rightMinUV, rightMaxUV, sprite, hasTransparency);
-            this.buildQuad(builder, format, isTxMirror, vertex000, vertex001, vertex011, vertex010, leftMinUV, leftMaxUV, sprite, hasTransparency);
-            this.buildQuad(builder, format, isTxMirror, vertex101, vertex001, vertex000, vertex100, topMinUV, rightMinUV, sprite, hasTransparency);
-            this.buildQuad(builder, format, isTxMirror, vertex110, vertex010, vertex011, vertex111, rightMinUV, topMaxUV, sprite, hasTransparency);
-            this.buildQuad(builder, format, isTxMirror, vertex100, vertex000, vertex010, vertex110, frontMinUV, frontMaxUV, sprite, hasTransparency);
-            this.buildQuad(builder, format, isTxMirror, vertex001, vertex101, vertex111, vertex011, backMinUV, backMaxUV, sprite, hasTransparency);
-            this.build(mat, builder, format, cube.getChildren(), sprite);
+            this.buildQuad(builder, format, isTxMirror, vertex101, vertex100, vertex110, vertex111, rightMinUV, rightMaxUV, sprite, hasTransparency, layer);
+            this.buildQuad(builder, format, isTxMirror, vertex000, vertex001, vertex011, vertex010, leftMinUV, leftMaxUV, sprite, hasTransparency, layer);
+            this.buildQuad(builder, format, isTxMirror, vertex101, vertex001, vertex000, vertex100, topMinUV, rightMinUV, sprite, hasTransparency, layer);
+            this.buildQuad(builder, format, isTxMirror, vertex110, vertex010, vertex011, vertex111, rightMinUV, topMaxUV, sprite, hasTransparency, layer);
+            this.buildQuad(builder, format, isTxMirror, vertex100, vertex000, vertex010, vertex110, frontMinUV, frontMaxUV, sprite, hasTransparency, layer);
+            this.buildQuad(builder, format, isTxMirror, vertex001, vertex101, vertex111, vertex011, backMinUV, backMaxUV, sprite, hasTransparency, layer);
+            this.build(mat, builder, format, cube.getChildren(), sprite, layer);
             mat.pop();
         }
     }
@@ -195,7 +196,7 @@ public class VanillaTabulaModel implements IModel {
         return false;
     }
 
-    private void buildQuad(ImmutableList.Builder<BakedQuad> builder, VertexFormat format, boolean isTxMirror, Point3f vert0, Point3f vert1, Point3f vert2, Point3f vert3, Point2i minUV, Point2i maxUV, TextureAtlasSprite sprite, boolean hasTransparency) {
+    private void buildQuad(ImmutableList.Builder<BakedQuad> builder, VertexFormat format, boolean isTxMirror, Point3f vert0, Point3f vert1, Point3f vert2, Point3f vert3, Point2i minUV, Point2i maxUV, TextureAtlasSprite sprite, boolean hasTransparency, int layer) {
         Point3f[] vertices = { vert0, vert1, vert2, vert3 };
         if (this.isQuadOneDimensional(vertices)) {
             return;
@@ -220,6 +221,7 @@ public class VanillaTabulaModel implements IModel {
         EnumFacing quadFacing = EnumFacing.getFacingFromVector(normal.x, normal.y, normal.z);
         quadBuilder.setQuadOrientation(quadFacing);
         quadBuilder.setTexture(sprite);
+        quadBuilder.setQuadTint(layer);
         float width = this.model.getTextureWidth();
         float height = this.model.getTextureHeight();
         for (int i = 0; i < vertices.length; i++) {


### PR DESCRIPTION
Currently the taubla baked model system will only apply the texture of `layer0`. This makes it so multiple textures can be layered on top of each-other, like in vanilla. This also makes it so tinting the models is possible, with `layer0` having a tint index of 0, `layer1` a tint index of 1 and so on.