### PR TITLE
Fixed BakedTabulaModel#getQuads 1.12.2

### DIFF
--- a/src/main/java/net/ilexiconn/llibrary/client/model/tabula/baked/BakedTabulaModel.java
+++ b/src/main/java/net/ilexiconn/llibrary/client/model/tabula/baked/BakedTabulaModel.java
@@ -2,6 +2,7 @@ package net.ilexiconn.llibrary.client.model.tabula.baked;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.block.model.IBakedModel;
@@ -36,7 +37,7 @@ public class BakedTabulaModel implements IBakedModel {
 
     @Override
     public List<BakedQuad> getQuads(IBlockState state, EnumFacing side, long rand) {
-        return this.quads;
+        return side == null ? this.quads : Lists.newArrayList();
     }
 
     @Override

--- a/src/main/java/net/ilexiconn/llibrary/client/model/tabula/baked/BakedTabulaModel.java
+++ b/src/main/java/net/ilexiconn/llibrary/client/model/tabula/baked/BakedTabulaModel.java
@@ -2,7 +2,6 @@ package net.ilexiconn.llibrary.client.model.tabula.baked;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.block.model.IBakedModel;
@@ -17,6 +16,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.commons.lang3.tuple.Pair;
 
 import javax.vecmath.Matrix4f;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -37,7 +37,7 @@ public class BakedTabulaModel implements IBakedModel {
 
     @Override
     public List<BakedQuad> getQuads(IBlockState state, EnumFacing side, long rand) {
-        return side == null ? this.quads : Lists.newArrayList();
+        return side == null ? this.quads : Collections.emptyList();
     }
 
     @Override


### PR DESCRIPTION
Minecraft iterates through all EnumFacings and calls getQuads. It then passes `null` as the EnumFacing. Returning all the quads every time means essentially you are rendering the model 7 times.

![image](https://user-images.githubusercontent.com/15876682/50532692-dc9c6800-0b14-11e9-9a89-503e0d2eb34d.png)