### PR TITLE
Possible fix for #91

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ llibrary.mappings
 .project
 .settings/
 *.launch
+/bin/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ out/
 *.iws
 secret.json
 llibrary.mappings
+.classpath
+.project
+.settings/
+*.launch

--- a/src/main/java/net/ilexiconn/llibrary/server/ServerEventHandler.java
+++ b/src/main/java/net/ilexiconn/llibrary/server/ServerEventHandler.java
@@ -104,7 +104,7 @@ public enum ServerEventHandler {
         List<PropertiesTracker<?>> trackers = EntityPropertiesHandler.INSTANCE.getEntityTrackers(player);
         if (trackers != null && trackers.size() > 0) {
             boolean hasPlayer = false;
-            for (PropertiesTracker tracker : trackers) {
+            for (PropertiesTracker<?> tracker : trackers) {
                 if (hasPlayer = tracker.getEntity() == player) {
                     break;
                 }
@@ -116,8 +116,9 @@ public enum ServerEventHandler {
                 tracker.updateTracker();
                 if (tracker.isTrackerReady()) {
                     tracker.onSync();
-                    PropertiesMessage message = new PropertiesMessage(tracker.getProperties(), tracker.getEntity());
+                    PropertiesMessage message = new PropertiesMessage(tracker, tracker.getEntity());
                     LLibrary.NETWORK_WRAPPER.sendTo(message, player);
+                    tracker.reset();
                 }
             }
         }

--- a/src/main/java/net/ilexiconn/llibrary/server/entity/PropertiesTracker.java
+++ b/src/main/java/net/ilexiconn/llibrary/server/entity/PropertiesTracker.java
@@ -14,7 +14,7 @@ public class PropertiesTracker<T extends Entity> {
     private boolean trackerReady = false;
     private boolean trackerDataChanged = false;
 
-    private NBTTagCompound prevTrackerData = new NBTTagCompound();
+    private SensitiveTagCompound trackingTag = new SensitiveTagCompound();
 
     private T entity;
     private EntityProperties properties;
@@ -42,12 +42,11 @@ public class PropertiesTracker<T extends Entity> {
         if (this.trackingUpdateTimer >= trackingUpdateFrequency) {
             if (!this.trackerDataChanged) {
                 this.trackingUpdateTimer = 0;
-                NBTTagCompound currentTrackingData = new NBTTagCompound();
-                this.properties.saveTrackingSensitiveData(currentTrackingData);
-                if (!currentTrackingData.equals(this.prevTrackerData)) {
+                this.properties.saveTrackingSensitiveData(trackingTag);
+                if (trackingTag.hasChanged()) {
                     this.trackerDataChanged = true;
+                    trackingTag.reset();
                 }
-                this.prevTrackerData = currentTrackingData;
             }
         }
     }

--- a/src/main/java/net/ilexiconn/llibrary/server/entity/PropertiesTracker.java
+++ b/src/main/java/net/ilexiconn/llibrary/server/entity/PropertiesTracker.java
@@ -42,10 +42,9 @@ public class PropertiesTracker<T extends Entity> {
         if (this.trackingUpdateTimer >= trackingUpdateFrequency) {
             if (!this.trackerDataChanged) {
                 this.trackingUpdateTimer = 0;
-                this.properties.saveTrackingSensitiveData(trackingTag);
-                if (trackingTag.hasChanged()) {
+                if (!this.trackingTag.hasChanged()) this.properties.saveTrackingSensitiveData(trackingTag);
+                if (this.trackingTag.hasChanged()) {
                     this.trackerDataChanged = true;
-                    trackingTag.reset();
                 }
             }
         }
@@ -68,6 +67,7 @@ public class PropertiesTracker<T extends Entity> {
             this.trackingTimer = 0;
             this.trackerReady = false;
             this.trackerDataChanged = false;
+            this.trackingTag.reset();
             return true;
         }
         return false;

--- a/src/main/java/net/ilexiconn/llibrary/server/entity/PropertiesTracker.java
+++ b/src/main/java/net/ilexiconn/llibrary/server/entity/PropertiesTracker.java
@@ -1,7 +1,6 @@
 package net.ilexiconn.llibrary.server.entity;
 
 import net.minecraft.entity.Entity;
-import net.minecraft.nbt.NBTTagCompound;
 
 /**
  * @param <T> the entity type
@@ -17,7 +16,7 @@ public class PropertiesTracker<T extends Entity> {
     private SensitiveTagCompound trackingTag = new SensitiveTagCompound();
 
     private T entity;
-    private EntityProperties properties;
+    private EntityProperties<T> properties;
 
     public PropertiesTracker(T entity, EntityProperties<T> properties) {
         this.entity = entity;
@@ -62,15 +61,7 @@ public class PropertiesTracker<T extends Entity> {
      * @return true if the data has changed and the tracking timer is ready and resets the tracking timer
      */
     public boolean isTrackerReady() {
-        boolean ready = this.properties.getTrackingTime() >= 0 && this.trackerReady && this.trackerDataChanged;
-        if (ready) {
-            this.trackingTimer = 0;
-            this.trackerReady = false;
-            this.trackerDataChanged = false;
-            this.trackingTag.reset();
-            return true;
-        }
-        return false;
+        return this.properties.getTrackingTime() >= 0 && this.trackerReady && this.trackerDataChanged;
     }
 
     /**
@@ -83,7 +74,7 @@ public class PropertiesTracker<T extends Entity> {
     /**
      * @return the properties
      */
-    public EntityProperties getProperties() {
+    public EntityProperties<T> getProperties() {
         return this.properties;
     }
 
@@ -100,4 +91,21 @@ public class PropertiesTracker<T extends Entity> {
     public void removeTracker() {
         this.properties.getTrackers().remove(this);
     }
+
+    /**
+     * @return The sensitive tag compound that keeps track of when things change.
+     */
+	public SensitiveTagCompound getTrackingTag() {
+		return trackingTag;
+	}
+
+	/**
+	 * Resets check states back to defaults (false or 0).
+	 */
+	public void reset() {
+        this.trackingTimer = 0;
+        this.trackerReady = false;
+        this.trackerDataChanged = false;
+        this.trackingTag.reset();
+	}
 }

--- a/src/main/java/net/ilexiconn/llibrary/server/entity/SensitiveTagCompound.java
+++ b/src/main/java/net/ilexiconn/llibrary/server/entity/SensitiveTagCompound.java
@@ -1,0 +1,97 @@
+package net.ilexiconn.llibrary.server.entity;
+
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTTagByte;
+import net.minecraft.nbt.NBTTagByteArray;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagDouble;
+import net.minecraft.nbt.NBTTagFloat;
+import net.minecraft.nbt.NBTTagInt;
+import net.minecraft.nbt.NBTTagIntArray;
+import net.minecraft.nbt.NBTTagLong;
+import net.minecraft.nbt.NBTTagShort;
+import net.minecraft.nbt.NBTTagString;
+
+public class SensitiveTagCompound extends NBTTagCompound {
+
+	private boolean changed = false;
+
+	@Override
+	public void setByte(String key, byte value) {
+		NBTBase b = this.tagMap.put(key, new NBTTagByte(value));
+		if (b == null) changed = true;
+		else if (b instanceof NBTTagByte && ((NBTTagByte) b).getByte() != value) changed = true;
+	}
+
+	@Override
+	public void setByteArray(String key, byte[] value) {
+		NBTBase b = this.tagMap.put(key, new NBTTagByteArray(value));
+		if (b == null) changed = true;
+		else if (b instanceof NBTTagByteArray && ((NBTTagByteArray) b).getByteArray() != value) changed = true;
+	}
+
+	@Override
+	public void setDouble(String key, double value) {
+		NBTBase b = this.tagMap.put(key, new NBTTagDouble(value));
+		if (b == null) changed = true;
+		else if (b instanceof NBTTagDouble && ((NBTTagDouble) b).getDouble() != value) changed = true;
+	}
+
+	@Override
+	public void setFloat(String key, float value) {
+		NBTBase b = this.tagMap.put(key, new NBTTagFloat(value));
+		if (b == null) changed = true;
+		else if (b instanceof NBTTagFloat && ((NBTTagFloat) b).getFloat() != value) changed = true;
+	}
+
+	@Override
+	public void setIntArray(String key, int[] value) {
+		NBTBase b = this.tagMap.put(key, new NBTTagIntArray(value));
+		if (b == null) changed = true;
+		else if (b instanceof NBTTagIntArray && ((NBTTagIntArray) b).getIntArray() != value) changed = true;
+	}
+
+	@Override
+	public void setInteger(String key, int value) {
+		NBTBase b = this.tagMap.put(key, new NBTTagInt(value));
+		if (b == null) changed = true;
+		else if (b instanceof NBTTagInt && ((NBTTagInt) b).getInt() != value) changed = true;
+	}
+
+	@Override
+	public void setLong(String key, long value) {
+		NBTBase b = this.tagMap.put(key, new NBTTagLong(value));
+		if (b == null) changed = true;
+		else if (b instanceof NBTTagLong && ((NBTTagLong) b).getLong() != value) changed = true;
+	}
+
+	@Override
+	public void setShort(String key, short value) {
+		NBTBase b = this.tagMap.put(key, new NBTTagShort(value));
+		if (b == null) changed = true;
+		else if (b instanceof NBTTagShort && ((NBTTagShort) b).getShort() != value) changed = true;
+	}
+
+	@Override
+	public void setString(String key, String value) {
+		NBTBase b = this.tagMap.put(key, new NBTTagString(value));
+		if (b == null) changed = true;
+		else if (b instanceof NBTTagString && !((NBTTagString) b).getString().equals(value)) changed = true;
+	}
+
+	@Override
+	public void setTag(String key, NBTBase value) {
+		NBTBase b = this.tagMap.put(key, value);
+		if (b == null) changed = true;
+		else if (!b.equals(value)) changed = true;
+	}
+
+	public boolean hasChanged() {
+		return changed;
+	}
+
+	public void reset() {
+		changed = false;
+	}
+
+}

--- a/src/main/java/net/ilexiconn/llibrary/server/entity/SensitiveTagCompound.java
+++ b/src/main/java/net/ilexiconn/llibrary/server/entity/SensitiveTagCompound.java
@@ -1,5 +1,8 @@
 package net.ilexiconn.llibrary.server.entity;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagByte;
 import net.minecraft.nbt.NBTTagByteArray;
@@ -15,75 +18,88 @@ import net.minecraft.nbt.NBTTagString;
 public class SensitiveTagCompound extends NBTTagCompound {
 
 	private boolean changed = false;
+	private Set<String> changedTags = new HashSet<>();
 
 	@Override
 	public void setByte(String key, byte value) {
 		NBTBase b = this.tagMap.put(key, new NBTTagByte(value));
-		if (b == null) changed = true;
-		else if (b instanceof NBTTagByte && ((NBTTagByte) b).getByte() != value) changed = true;
+		if (b == null) updateChanged(key);
+		else if (b instanceof NBTTagByte && ((NBTTagByte) b).getByte() != value) updateChanged(key);
 	}
 
 	@Override
 	public void setByteArray(String key, byte[] value) {
 		NBTBase b = this.tagMap.put(key, new NBTTagByteArray(value));
-		if (b == null) changed = true;
-		else if (b instanceof NBTTagByteArray && ((NBTTagByteArray) b).getByteArray() != value) changed = true;
+		if (b == null) updateChanged(key);
+		else if (b instanceof NBTTagByteArray && ((NBTTagByteArray) b).getByteArray() != value) updateChanged(key);
 	}
 
 	@Override
 	public void setDouble(String key, double value) {
 		NBTBase b = this.tagMap.put(key, new NBTTagDouble(value));
-		if (b == null) changed = true;
-		else if (b instanceof NBTTagDouble && ((NBTTagDouble) b).getDouble() != value) changed = true;
+		if (b == null) updateChanged(key);
+		else if (b instanceof NBTTagDouble && ((NBTTagDouble) b).getDouble() != value) updateChanged(key);
 	}
 
 	@Override
 	public void setFloat(String key, float value) {
 		NBTBase b = this.tagMap.put(key, new NBTTagFloat(value));
-		if (b == null) changed = true;
-		else if (b instanceof NBTTagFloat && ((NBTTagFloat) b).getFloat() != value) changed = true;
+		if (b == null) updateChanged(key);
+		else if (b instanceof NBTTagFloat && ((NBTTagFloat) b).getFloat() != value) updateChanged(key);
 	}
 
 	@Override
 	public void setIntArray(String key, int[] value) {
 		NBTBase b = this.tagMap.put(key, new NBTTagIntArray(value));
-		if (b == null) changed = true;
-		else if (b instanceof NBTTagIntArray && ((NBTTagIntArray) b).getIntArray() != value) changed = true;
+		if (b == null) updateChanged(key);
+		else if (b instanceof NBTTagIntArray && ((NBTTagIntArray) b).getIntArray() != value) updateChanged(key);
 	}
 
 	@Override
 	public void setInteger(String key, int value) {
 		NBTBase b = this.tagMap.put(key, new NBTTagInt(value));
-		if (b == null) changed = true;
-		else if (b instanceof NBTTagInt && ((NBTTagInt) b).getInt() != value) changed = true;
+		if (b == null) updateChanged(key);
+		else if (b instanceof NBTTagInt && ((NBTTagInt) b).getInt() != value) updateChanged(key);
 	}
 
 	@Override
 	public void setLong(String key, long value) {
 		NBTBase b = this.tagMap.put(key, new NBTTagLong(value));
-		if (b == null) changed = true;
-		else if (b instanceof NBTTagLong && ((NBTTagLong) b).getLong() != value) changed = true;
+		if (b == null) updateChanged(key);
+		else if (b instanceof NBTTagLong && ((NBTTagLong) b).getLong() != value) updateChanged(key);
 	}
 
 	@Override
 	public void setShort(String key, short value) {
 		NBTBase b = this.tagMap.put(key, new NBTTagShort(value));
-		if (b == null) changed = true;
-		else if (b instanceof NBTTagShort && ((NBTTagShort) b).getShort() != value) changed = true;
+		if (b == null) updateChanged(key);
+		else if (b instanceof NBTTagShort && ((NBTTagShort) b).getShort() != value) updateChanged(key);
 	}
 
 	@Override
 	public void setString(String key, String value) {
 		NBTBase b = this.tagMap.put(key, new NBTTagString(value));
-		if (b == null) changed = true;
-		else if (b instanceof NBTTagString && !((NBTTagString) b).getString().equals(value)) changed = true;
+		if (b == null) updateChanged(key);
+		else if (b instanceof NBTTagString && !((NBTTagString) b).getString().equals(value)) updateChanged(key);
 	}
 
 	@Override
 	public void setTag(String key, NBTBase value) {
 		NBTBase b = this.tagMap.put(key, value);
-		if (b == null) changed = true;
-		else if (!b.equals(value)) changed = true;
+		if (b == null) updateChanged(key);
+		else if (!b.equals(value)) updateChanged(key);
+	}
+
+	public void updateChanged(String key) {
+		changedTags.add(key);
+		changed = true;
+	}
+
+	public NBTTagCompound getChangedCopy() {
+		NBTTagCompound tag = new NBTTagCompound();
+		for (String s : changedTags)
+			tag.tagMap.put(s, this.tagMap.get(s));
+		return tag;
 	}
 
 	public boolean hasChanged() {
@@ -92,6 +108,7 @@ public class SensitiveTagCompound extends NBTTagCompound {
 
 	public void reset() {
 		changed = false;
+		changedTags.clear();
 	}
 
 }

--- a/src/main/java/net/ilexiconn/llibrary/server/network/PropertiesMessage.java
+++ b/src/main/java/net/ilexiconn/llibrary/server/network/PropertiesMessage.java
@@ -4,6 +4,7 @@ import io.netty.buffer.ByteBuf;
 import net.ilexiconn.llibrary.server.capability.EntityDataHandler;
 import net.ilexiconn.llibrary.server.capability.IEntityData;
 import net.ilexiconn.llibrary.server.entity.EntityProperties;
+import net.ilexiconn.llibrary.server.entity.PropertiesTracker;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
@@ -23,11 +24,9 @@ public class PropertiesMessage extends AbstractMessage<PropertiesMessage> {
 
     }
 
-    public PropertiesMessage(EntityProperties<?> properties, Entity entity) {
-        this.propertyID = properties.getID();
-        NBTTagCompound compound = new NBTTagCompound();
-        properties.saveTrackingSensitiveData(compound);
-        this.compound = compound;
+    public PropertiesMessage(PropertiesTracker<?> tracker, Entity entity) {
+        this.propertyID = tracker.getProperties().getID();
+        this.compound = tracker.getTrackingTag().getChangedCopy();
         this.entityID = entity.getEntityId();
     }
 
@@ -38,7 +37,7 @@ public class PropertiesMessage extends AbstractMessage<PropertiesMessage> {
         if (entity != null) {
             IEntityData<?> extendedProperties = EntityDataHandler.INSTANCE.getEntityData(entity, message.propertyID);
             if (extendedProperties instanceof EntityProperties) {
-                EntityProperties<?> properties = (EntityProperties) extendedProperties;
+                EntityProperties<?> properties = (EntityProperties<?>) extendedProperties;
                 properties.loadTrackingSensitiveData(message.compound);
                 properties.onSync();
             }

--- a/src/main/resources/META-INF/llibrary_at.cfg
+++ b/src/main/resources/META-INF/llibrary_at.cfg
@@ -8,3 +8,4 @@ public net.minecraft.client.network.NetworkPlayerInfo field_178863_g #skinType
 public net.minecraft.client.entity.AbstractClientPlayer func_175155_b()Lnet/minecraft/client/network/NetworkPlayerInfo; #getPlayerInfo
 public net.minecraft.client.renderer.entity.RenderPlayer func_177137_d(Lnet/minecraft/client/entity/AbstractClientPlayer;)V #setModelVisibilities
 public net.minecraft.util.Timer field_194149_e #tickLength
+public net.minecraft.nbt.NBTTagCompound field_74784_a # tagMap


### PR DESCRIPTION
The problem with the entity sync manager (asides from the fact that it exists) is that it uses a very expensive method of checking if the data has changed.  This can instead be implemented at the tag compound level, as is done here.  This removes the calls to NBTTagCompound#equals and instead only logs changes when tags are updated.