### PR TITLE
Fix llibrary_patrons.json URL

### DIFF
--- a/src/main/java/net/ilexiconn/llibrary/client/ClientProxy.java
+++ b/src/main/java/net/ilexiconn/llibrary/client/ClientProxy.java
@@ -43,7 +43,7 @@ public class ClientProxy extends ServerProxy {
     @Override
     public void onPreInit() {
         super.onPreInit();
-        ListenableFuture<String> patronFuture = WebUtils.readURLAsync("https://gist.githubusercontent.com/gegy1000/7a6d39cf7a2c1f794ffb9037e8146adc/raw/llibrary_patrons.json");
+        ListenableFuture<String> patronFuture = WebUtils.readURLAsync("https://gist.githubusercontent.com/gegy/7a6d39cf7a2c1f794ffb9037e8146adc/raw/llibrary_patrons.json");
         patronFuture.addListener(() -> {
             try {
                 String result = patronFuture.get();


### PR DESCRIPTION
Mod version 1.7.19 for MC 1.12.2 generates a gnarly crash report in the logs when run due to the URL for llibrary_patrons.json being wrong. This fixes it to point to the working URL as pointed out in comments on the mods curseforge page.